### PR TITLE
refactor: 게시글에 표시되는 사용자 ID를 닉네임으로 변경

### DIFF
--- a/Acorn/src/main/java/com/controller/board/BoardContentController.java
+++ b/Acorn/src/main/java/com/controller/board/BoardContentController.java
@@ -26,7 +26,8 @@ public class BoardContentController implements BoardController {
 		model.put("postText", post.getPostText()); // 게시글 내용
 		model.put("postTitle", post.getPostTitle()); // 게시글 제목
 		model.put("postDate", post.getPostDate()); // 게시글 작성일
-		model.put("userId", post.getUserId()); // 게시글 작성자의 사용자 ID
+		model.put("nickname", post.getNickname()); // 게시글 작성자의 사용자 닉네임
+		
 		
 		//게시물 조회수 업데이트
 		service.updateViewNum(postId);

--- a/Acorn/src/main/webapp/WEB-INF/board/boardView.jsp
+++ b/Acorn/src/main/webapp/WEB-INF/board/boardView.jsp
@@ -161,7 +161,7 @@ color:red;
 					<div class="col-md-6"><%= post.getPostTitle() %></div>
 					<div class="col-md-3">
 					
-						<%= post.getUserId() %></div>
+						<%= post.getNickname() %></div>
 					<fmt:formatDate value="<%= post.getPostDate() %>"
 						pattern="yyyy-MM-dd" var="formattedDate" />
 					<div class="col-md-3">${formattedDate}</div>

--- a/Acorn/src/main/webapp/WEB-INF/board/content.jsp
+++ b/Acorn/src/main/webapp/WEB-INF/board/content.jsp
@@ -211,7 +211,7 @@
 			<div class="post-meta">
 				<fmt:formatDate value="${postDate}" pattern="yyyy.MM.dd hh:dd:ss"
 					var="formattedDate" />
-				<small>작성자: ${userId}  |  작성일: ${formattedDate}</small>
+				<small>작성자: ${nickname}  |  작성일: ${formattedDate}</small>
 			</div>
 			<hr>
 			<!-- 글 내용 -->


### PR DESCRIPTION
게시글에 출력되는 사용자 식별자를 'userId'에서 'nickname'으로 변경했습니다. 이 변경은 사용자 경험을 개선하고, 게시글의 가독성을 높이기 위한 것입니다. 이제 게시글에는 사용자의 닉네임이 표시되어, 누가 글을 작성했는지 더 명확하게 인식할 수 있습니다.